### PR TITLE
Fix typo in src/Makefile.am

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1403,6 +1403,9 @@ AC_CONFIG_LINKS([contrib/filter-lcov.py:contrib/filter-lcov.py])
 AC_CONFIG_LINKS([test/functional/test_runner.py:test/functional/test_runner.py])
 AC_CONFIG_LINKS([test/util/bitcoin-util-test.py:test/util/bitcoin-util-test.py])
 AC_CONFIG_LINKS([test/util/rpcauth-test.py:test/util/rpcauth-test.py])
+dnl FXTC BEGIN
+AC_CONFIG_LINKS([src/crypto/md_helper.c:src/crypto/md_helper.c])
+dnl FXTC END
 
 dnl boost's m4 checks do something really nasty: they export these vars. As a
 dnl result, they leak into secp256k1's configure and crazy things happen.


### PR DESCRIPTION
Commit to fix the typo "flatdatabase.h" to "flat-database.h" in src/Makefile.am, otherwise for example Travis will fail on the first build:

make[1]: *** No rule to make target 'flatdatabase.h', needed by 'distdir'.  Stop.