### PR TITLE
Fix shellcheck URL

### DIFF
--- a/.travis/lint_04_install.sh
+++ b/.travis/lint_04_install.sh
@@ -11,5 +11,5 @@ travis_retry pip install flake8==3.5.0
 travis_retry pip install vulture==0.29
 
 SHELLCHECK_VERSION=v0.6.0
-curl -s "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
+curl -s "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
 export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"


### PR DESCRIPTION
Fix Travis-CI error:
```
You are downloading ShellCheck from an outdated URL!

Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/v0.6.0/shellcheck-v0.6.0.linux.x86_64.tar.xz

For more information, see:
https://github.com/koalaman/shellcheck/issues/1871

PS: Sorry for breaking your build. The hosting costs were getting out of hand :(
^---- failure generated from test/lint/lint-shell.sh
```